### PR TITLE
Issue No. #61 [BUG FIXED] In the footer section, the copyright year should be dynamically generated instead of being statically hardcoded.

### DIFF
--- a/copyrightYear.js
+++ b/copyrightYear.js
@@ -1,0 +1,4 @@
+let copyRightYear = document.getElementById("copyright-year");
+let currentDate = new Date();
+let currentYear = currentDate.getFullYear();
+copyRightYear.innerText = currentYear;

--- a/index.html
+++ b/index.html
@@ -193,10 +193,12 @@
 
         <hr />
         <div class="copyright">
-          <p>&copy; 2023 Cinephile. All rights reserved.</p>
+          <p>&copy; <span id="copyright-year"></span> Cinephile. All rights reserved.</p>
         </div>
       </div>
     </div>
+     <!-- copyright-year Script -->
+     <script src="./copyrightYear.js"></script>
     <!--=============== GSAP ===============-->
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"></script>

--- a/tvshows.html
+++ b/tvshows.html
@@ -190,10 +190,13 @@
 
         <hr />
         <div class="copyright">
-          <p>&copy; 2023 Cinephile. All rights reserved.</p>
+          <p>&copy; <span id="copyright-year"></span> Cinephile. All rights reserved.</p>
         </div>
       </div>
     </div>
+
+    <!-- copyright-year Script -->
+    <script src="./copyrightYear.js"></script>
     <!--=============== GSAP ===============-->
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"></script>


### PR DESCRIPTION
Closes #61 